### PR TITLE
Monk: Add Monk Kit on master branch

### DIFF
--- a/Dockerfile.echo-cli
+++ b/Dockerfile.echo-cli
@@ -1,0 +1,8 @@
+FROM golang:1.18 AS builder
+WORKDIR /app
+COPY echo-cli/main.go .
+RUN go build -o echo-cli main.go
+
+FROM gcr.io/distroless/base-debian10
+COPY --from=builder /app/echo-cli /
+ENTRYPOINT ["/echo-cli"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO c10k-go
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,48 @@
+namespace: c10k-go
+
+echo-cli:
+  defines: runnable
+  metadata:
+    name: echo-cli
+    description: >-
+      A benchmarking client for establishing concurrent connections and
+      measuring response times.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    echo-cli:
+      image: env-3211.registry.local/echo-cli:master-75aecbb
+      build: .
+      dockerfile: Dockerfile.echo-cli
+  services: {}
+  connections:
+    echo-cli-to-echo-serv:
+      target: c10k-go/echo-serv
+      service: '!!!SETME!!!'
+      optional: true
+      description: Connection from echo-cli to echo-serv service
+  variables:
+    echo-cli-nr-conn:
+      env: ECHO_CLI_NR_CONN
+      type: int
+      value: '10'
+      description: Number of concurrent connections
+    echo-cli-nr-msg:
+      env: ECHO_CLI_NR_MSG
+      type: int
+      value: '10'
+      description: Number of messages per connection
+    echo-cli-serv-addr:
+      env: ECHO_CLI_SERV_ADDR
+      type: string
+      value: <- connection-port("echo-cli-to-echo-serv")
+      description: Server address
+    echo-cli-out:
+      env: ECHO_CLI_OUT
+      type: string
+      value: '!!!SETME!!!'
+      description: Output file name
+
+stack:
+  defines: group
+  members:
+    - c10k-go/echo-cli


### PR DESCRIPTION
# Containerization and Deployment Configuration for c10k-go Application

This PR introduces the necessary Docker and Monk.io configurations to containerize and deploy the c10k-go application, which consists of two Go services designed for a c10k benchmark: `echo-cli` and `echo-serv`.

### Dockerfile for `echo-cli`
I've successfully created a Dockerfile for the `echo-cli` service. This Dockerfile uses a multi-stage build process with a Go base image to build the binary and then copies it to a distroless base image for execution. The service is designed to connect to the `echo-serv` service and does not expose any ports or require environment variables. The Dockerfile is confirmed to be correctly set up, as the service attempts to connect to `echo-serv` on localhost:8080 and receives a 'connection refused' error due to the absence of the `echo-serv` service in the isolated build environment.

### Dockerfile for `echo-serv`
The creation of a Dockerfile for the `echo-serv` service was unsuccessful. The build process failed due to the absence of a `go.mod` file, which is required for Go module dependency management. As a result, the Dockerfile could not build the application. The source code needs to be updated to include a `go.mod` file before the Dockerfile can be successfully built.

### Monk.io Configuration
I've added a `monk.yaml` file that contains the Monk.io configuration for deploying the application. Additionally, a `MANIFEST` file has been included, which lists all the Monk.io YAML files that should be deployed to Monk.io.

### Next Steps
To proceed with the deployment of the `echo-serv` service, the source code must be updated to include a `go.mod` file for proper dependency management. Once this is done, the Dockerfile for `echo-serv` can be revisited and finalized. After merging this PR, the application will be re-deployed on each subsequent push, provided that the `echo-serv` Dockerfile issue is resolved.

### Summary of Changes
- Added `Dockerfile.echo-cli` for the `echo-cli` service.
- Added `monk.yaml` for Monk.io deployment configuration.
- Added `MANIFEST` to list Monk.io configuration files.

Please update the `echo-serv` source code to include a `go.mod` file and adjust the Dockerfile accordingly to complete the containerization process.