### PR TITLE
Monk: Add Monk Kit on master branch

### DIFF
--- a/Dockerfile.echo-cli
+++ b/Dockerfile.echo-cli
@@ -1,0 +1,8 @@
+FROM golang:1.18 AS builder
+WORKDIR /app
+copy echo-cli/main.go .
+RUN go mod init echo-cli && go build -o echo-cli
+
+FROM debian:buster-slim
+COPY --from=builder /app/echo-cli /echo-cli
+ENTRYPOINT ["/echo-cli"]

--- a/Dockerfile.echo-serv
+++ b/Dockerfile.echo-serv
@@ -1,0 +1,10 @@
+FROM golang:1.18 AS builder
+WORKDIR /app
+COPY echo-serv/ .
+RUN go mod init echo-serv && go mod tidy
+RUN go build -o echo-serv
+
+FROM gcr.io/distroless/base-debian10
+COPY --from=builder /app/echo-serv /
+EXPOSE 8080
+ENTRYPOINT ["/echo-serv"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO c10k-go
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,73 @@
+namespace: c10k-go
+
+echo-cli:
+  defines: runnable
+  metadata:
+    name: echo-cli
+    description: >-
+      A benchmarking client that establishes multiple concurrent connections to
+      a server to measure performance.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    echo-cli:
+      image: env-2121.registry.local/echo-cli:master-75aecbb
+      build: .
+      dockerfile: Dockerfile.echo-cli
+  services: {}
+  connections:
+    echo-server-connection:
+      target: c10k-go/echo-serv
+      service: tcp-echo
+      optional: true
+      description: Connection from echo-cli to echo-serv to send and receive echo messages
+  variables:
+    echo-cli-nr-conn:
+      env: ECHO_CLI_NR_CONN
+      type: int
+      value: '10'
+      description: Number of concurrent connections to establish with the server
+    echo-cli-nr-msg:
+      env: ECHO_CLI_NR_MSG
+      type: int
+      value: '10'
+      description: Number of messages to send per connection
+    echo-cli-server-addr:
+      env: ECHO_CLI_SERVER_ADDR
+      type: string
+      value: <- connection-port("echo-server-connection")
+      description: Address of the server to connect to
+    echo-cli-output-file:
+      env: ECHO_CLI_OUTPUT_FILE
+      type: string
+      value: results.txt
+      description: Name of the output file to write results to
+
+echo-serv:
+  defines: runnable
+  metadata:
+    name: echo-serv
+    description: >-
+      A server that listens for incoming TCP connections and echoes back
+      received data.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    echo-serv:
+      image: env-2121.registry.local/echo-serv:master-75aecbb
+      build: .
+      dockerfile: Dockerfile.echo-serv
+  services:
+    tcp-echo:
+      description: TCP port for echoing messages back to the client
+      container: echo-serv
+      port: 8080
+      host-port: 8080
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - c10k-go/echo-cli
+    - c10k-go/echo-serv


### PR DESCRIPTION
# Containerization and Deployment Configuration for c10k-go Application

## Summary of Changes

I have successfully containerized the two Go services (`echo-cli` and `echo-serv`) for the c10k benchmark application and prepared them for deployment. Below are the key changes and configurations made:

- **Dockerfiles Creation**: Dockerfiles for both `echo-cli` and `echo-serv` services have been created. The `echo-cli` service is a benchmarking client, and `echo-serv` is the server counterpart.
- **Dockerfile for `echo-cli`**: Encountered an issue due to the absence of a `go.mod` file. I resolved this by adjusting the Dockerfile to initialize a Go module before building the application.
- **Dockerfile for `echo-serv`**: Successfully built the Dockerfile which sets up a distroless container to run the server application.
- **Monk.io Configuration**: Added `monk.yaml` and `MANIFEST` files for Monk.io configuration, ensuring the application is ready for deployment.

## Instructions for Continuation

- **Merge PR**: The application is ready for re-deployment. Merging this PR will ensure that the application is redeployed on each subsequent push.
- **No Further Action Required**: The `echo-cli` and `echo-serv` services are configured correctly. The `echo-cli` service does not expose any ports as it is a client, and the `echo-serv` service exposes a single TCP port 8080.

## Additional Notes

- The `echo-cli` service is designed to establish multiple concurrent connections to the `echo-serv` server to measure performance. The Dockerfile for `echo-cli` is set up correctly, and the service is working as expected within the isolated environment.
- The `echo-serv` service listens for incoming TCP connections on port 8080 and echoes back received data. The Dockerfile for `echo-serv` is also set up correctly, and the service is functioning as intended.

Please review the changes and proceed to merge the PR to deploy the updated application.